### PR TITLE
Quick Mill 0835 & 3000 PID Werte und Typos

### DIFF
--- a/de/customization/brueherkennung.md
+++ b/de/customization/brueherkennung.md
@@ -21,7 +21,7 @@ Wie in dem vorherigen Kapitel erwähnt, soll der **brew heater detection limit**
 
 ## Konfiguration der Erkennung
 
-Die Bezugserkennnung wird beim Only PID oder Vollausbau unterschiedlich realisiert. In folgender Zeile in der Userconfig kann diese konfiguriert werden: 
+Die Bezugserkennung wird beim Only PID oder Vollausbau unterschiedlich realisiert. In folgender Zeile in der User Config kann diese konfiguriert werden: 
 ```
 #define BREWDETECTION 1            
 // 0 = off, 1 = Software, 2 = Hardware, 3 = Sensor/Hardware for Only PID 
@@ -35,7 +35,7 @@ Als Ergänzung wurde eine Lösung zwischen Only PID und Vollausbau entwickelt (O
 // BREWDETECTION 3 configuration
 #define VOLTAGESENSORTYPE HIGH 
 #define PINMODEVOLTAGESENSOR INPUT // Mode INPUT_PULLUP, INPUT or INPUT_PULLDOWN_16 (Only Pin 16)
-#define PINVOLTAGESENSOR  15    //Input pin for volatage sensor
+#define PINVOLTAGESENSOR  15    //Input pin for voltage sensor
 ```
 PINVOLTAGESENSOR gibt den gewählten PIN am NodeMCU an. "VOLTAGESENSORTYPE HIGH" bedeutet, dass der Sensor ein HIGH Signal (3,3 Volt) ausgibt, wenn der Schalter gedrückt ist. "VOLTAGESENSORTYPE LOW" muss gewählt werden, wenn bei gedrücktem Schalter am Sensor ein LOW Signal (GND) ausgegeben wird. Je nach gewählten PIN und Aufbau muss ggf. ein INPUT Pullup oder Pulldown (nur Pin 16) erfolgen (PINMODEVOLTAGESENSOR INPUT oder INPUT_PULLUP oder INPUT_PULLDOWN_16). Hintergrund ist, dass durch ein Pullup oder Pulldown der PIN am NodeMCU definiert in LOW oder HIGH gehalten wird, um dann genau das gegensätzliche Signal vom Sensor zu messen. 
 
@@ -49,7 +49,7 @@ Der Sensor erhält 3,3 Volt und die andere Seite wird mit PIN 15 verbunden
 // BREWDETECTION 3 configuration
 #define VOLTAGESENSORTYPE HIGH 
 #define PINMODEVOLTAGESENSOR INPUT // Mode INPUT_PULLUP, INPUT or INPUT_PULLDOWN_16 (Only Pin 16)
-#define PINVOLTAGESENSOR  15    //Input pin for volatage sensor
+#define PINVOLTAGESENSOR  15    //Input pin for voltage sensor
 ```
 
 2. 220V Sensor (Optokoppler - TTL AC 220V Isolation Modul SCM Test Board)
@@ -78,7 +78,7 @@ Vereinfacht kann festgehalten werden, dass die „brew heater detection limit“
 Wenn die Erkennung ausgelöst wird, dann gelten für den definierten Zeitraum - welcher in „brew timer Software Seconds“ (im oberen Screenshot, 120 Sekunden) definiert ist - andere PID Werte. Somit kann der Regler nun aggressiver auf den Brühvorgang reagieren und schneller hochheizen. Wichtig ist hierbei dass jede Unterschreitung des Grenzwertes zu einer Auslösung der Erkennung führt. Der Verlauf nach dem Auslösen wird nicht weiter ausgewertet, sondern die geänderten PID Werte gelten fix für die definierte Zeit nach der Erkennung des Bezuges.
 
 ## PID Werte
-Die geänderten PID Werte gelten immer, wenn ein Brühvorgang erkannt wird, sei es per Sofware oder im Vollausbau durch die Abfrage am Brühschalter. Die Zeitdauer wird mit "brew timer Software Seconds" in der Blynksteuerung festgelegt. 
+Die geänderten PID Werte gelten immer, wenn ein Brühvorgang erkannt wird, sei es per Software oder im Vollausbau durch die Abfrage am Brühschalter. Die Zeitdauer wird mit "brew timer Software Seconds" in der Blynksteuerung festgelegt. 
 Für den kurzen Zeitraum muss der PID schnell wieder auf Temperatur kommen, ohne überzuschwingen. Hierzu muss vor allem der I-Anteil erhöht werden, damit sich der Regler nicht die erfolgte Abweichung vom Soll-Wert für die Zukunft „merkt“. Der D-Anteil kann auch erhöht werden, um den Regler beim Abfallen der Temperatur zu „beschleunigen“ und „abzubremsen“, wenn die Temperatur wieder Richtung Soll-Wert geht. Als Größenordnung können die Werte aus dem oberen Screenshot genommen werden.
 In der nachfolgenden Tabelle sind bewährte PID für die Brüherkennung zu finden.
 
@@ -87,6 +87,8 @@ Maschine |	P |	I |	D | Timer |  Limit
 Rancilio Silvia (nicht isoliert) | 50 | 0 | 20 | 120 | 45 
 Rancilio Silvia E (isoliert) | 70 | 0 | 20 | 240 | 65 
 Gaggia | 75 | 0 | 15 | 180 | 90 
+Quick Mill (Modell 0835 & 3000) | 80 | 0 | 80 | 100 | tbd.
+
 
 ## Vergleich bei einem Bezug
 

--- a/de/customization/pid-werte.md
+++ b/de/customization/pid-werte.md
@@ -21,7 +21,7 @@ Hier möchten wir dir die wesentlichen Bedienelemente der PID in Blynk erläuter
 
 ## Einführung
 
-Wir haben festgestellt, dass ein Regler benötigt wird um perfekt auf Solltemperatur zu regeln und dieser übergibt dann an den zweiten Regler für den regulären Betrieb. Dieser muss sich dann um das perfekte Regeln am Sollpunkt kümmern. Der Brühvorgang stellt eine besondere Abweichung da, die wir versuchen mit der Brüherkennung zu optimieren. Auch dies ist ein separater Regler.
+Wir haben festgestellt, dass ein Regler benötigt wird, um perfekt auf Solltemperatur zu regeln und dieser übergibt dann an den zweiten Regler für den regulären Betrieb. Dieser muss sich dann um das perfekte Regeln am Sollpunkt kümmern. Der Brühvorgang stellt eine besondere Abweichung dar, die wir versuchen mit der Brüherkennung zu optimieren. Auch dies ist ein separater Regler.
 
 ![PID-Einführung](../../img/Bildschirmfoto-2020-11-04-um-20.51.31-1536x733.png)
 
@@ -31,7 +31,7 @@ Bereich | Erklärung
 2 | Regulärer Betrieb
 3 | Brüherkennung (BD)
 
-Es ist empfehlenswert, unter dem Punkt Brüherkennung diese am Anfang zu deaktiveren. Dies erreichst du mit einem **brew heater detection limit** von 0 (V34). Dann stört diese nicht beim ersten Betrieb. Die Brüherkennung wird im nachfolgenden [Teil](brueherkennung.md) genauer erläutert.
+Es ist empfehlenswert, unter dem Punkt Brüherkennung diese am Anfang zu deaktivieren. Dies erreichst du mit einem **brew heater detection limit** von 0 (V34). Dann stört diese nicht beim ersten Betrieb. Die Brüherkennung wird im nachfolgenden [Teil](brueherkennung.md) genauer erläutert.
 
 Es somit drei Regler/Bereiche:
 
@@ -45,7 +45,7 @@ Der Kaltstart ist aktiv bis zur Solltemperatur, danach gilt der reguläre PID. W
 
 Reguläre PID Einstellung (roter Kasten)
 
-Der Kaltstart befindet sich im „Expertenmodus“ Reiter in der Blynk App. Dieser ist nur aktiv wenn in der **Userconfig „Coldstart = 2“ gewählt wird!** Sonst gelten vordefinierte Standardwerte.
+Der Kaltstart befindet sich im „Expertenmodus“ Reiter in der Blynk App. Dieser ist nur aktiv wenn in der **User Config „Coldstart = 2“ gewählt wird!** Sonst gelten vordefinierte Standardwerte.
 
 ![Erklärung Brüherkennung](../../img/Bildschirmfoto-2020-11-04-um-19.46.38.png)
 
@@ -63,7 +63,7 @@ Der I Anteil – genauer gesagt Tn – ist dafür da, eine stetige Reglerabweich
 
 Der D Anteil ist dafür da auf plötzliche Reglerabweichungen zu reagieren. Hierbei wird die zeitliche Veränderung / Steigung analysiert. Der D Anteil ist für das „schnelle Eingreifen“ hilfreich.
 
-Ein PI Regler – ohne D Anteil – reicht bei einer Espressomaschine im normalen Betrieb vollkommen aus, um diese auf ca. 0,1 °C genau zu regeln. Dennoch könnt Ihr gerne D anpassen, falls es euch hilft.
+Ein PI Regler – ohne D Anteil – reicht bei einer Espressomaschine im normalen Betrieb vollkommen aus, um diese auf ca. 0,1 °C genau zu regeln. Dennoch könnt ihr gerne D anpassen, falls es euch hilft.
 
 Anmerkung: Der PI Regler im Kaltstart verhält sich aber anders.
 
@@ -76,6 +76,7 @@ Rancilio Silvia E ( isoliert) | 25 | 250 | 0 |
 Gaggia (Modell 9480 & 9303) | 67 | 670 | 0
 Gaggia (Modell 9403) | 55 | 800 | 0
 E 61 | 70 | 150 | 0
+Quick Mill (Modell 0835 & 3000) | 80 | 75 | 0
 
 ## Kaltstart
 
@@ -93,22 +94,23 @@ Rancilio Silvia (nicht isoliert) | 45 |	130
 Rancilio Silvia E (isoliert) | 35 |	130
 Gaggia (Modell 9403, Baujahr 2015) |	23 | 175
 E 61 |	70 |	96
+Quick Mill (Modell 0835 & 3000) | 250 | 35
 
-Folgende Grafik soll euch bei der Einstellungen vom Kaltstart helfen, wenn Ihr diesen selber einstellen wollt. Das Grundprinzip des Reglern beim Kaltstart ist hier beschrieben (auf Englisch): [Link](http://brettbeauregard.com/blog/2017/06/introducing-proportional-on-measurement/).
+Folgende Grafik soll euch bei der Einstellungen vom Kaltstart helfen, wenn ihr diesen selber einstellen wollt. Das Grundprinzip des Reglern beim Kaltstart ist hier beschrieben (auf Englisch): [Link](http://brettbeauregard.com/blog/2017/06/introducing-proportional-on-measurement/).
 
 ![PID-Kurven](../../img/image.png)
 
 Diese Grafik zeigt euch qualitativ, wie sich die Kaltstartkurve verschiebt, wenn P oder I verändert werden. Das Ziel von dem Kaltstart sollte sein, dass die Maschine ohne ein nennenswerte Überschwingen perfekt auf die Solltemperatur landet. (vgl. Kurve P 45, I 130).
 
 Das deutliche Überschwingen sollte vermieden werden, da der I Anteil übergeben wird an den neuen Reglerabschnitt. Der Regler hat dann deutlich schwieriger die Solltemperatur sofort zu halten. Dies ist aber auch nur eine Empfehlung, manche Spülen sowieso und stört das Überschwingen nicht oder warten trotzdem 20 Minuten bis zum ersten Espresso.
-Die genannten Werte (P,I) dienen mehr zur Orientierung und sollen euch helfen, wenn Ihr den Kaltstart selber einstellen möchtet. Man sollte nicht zwei Werte gleichzeitig verändern, da dies bei der Auswertung hinderlich sein könnte.
+Die genannten Werte (P,I) dienen mehr zur Orientierung und sollen euch helfen, wenn ihr den Kaltstart selber einstellen möchtet. Man sollte nicht zwei Werte gleichzeitig verändern, da dies bei der Auswertung hinderlich sein könnte.
 
-Falls Ihr völlig andere Parameter nutzen müsst, da Ihr einen anderen Maschinentyp habt, kann euch auch der Kurvenverlauf helfen, wie Ihr P oder I nacheinander verändern müsst, um die Kurve optimal einzustellen.
+Falls ihr völlig andere Parameter nutzen müsst, da ihr einen anderen Maschinentyp habt, kann euch auch der Kurvenverlauf helfen, wie ihr P oder I nacheinander verändern müsst, um die Kurve optimal einzustellen.
 
 ## Fall 1) Maschine heizt zu langsam auf
 
-Hier kann es helfen erst mal I zu reduzieren und dann zu sehen, ob die Kurve sich schneller an die Solltempertur annährt. Danach könnte I wieder auf den ursprünglichen Wert eingestellt werden, P angepasst werden, falls die Kurve immer noch zu flach ist und ggf. diesen „leichten Knick“ (ca. bei 2 Minuten zu sehen) hat (siehe Bild P 60 und I 240 und P45 und I 240).
+Hier kann es helfen erst mal I zu reduzieren und dann zu sehen, ob die Kurve sich schneller an die Solltemperatur annähert. Danach könnte I wieder auf den ursprünglichen Wert eingestellt werden, P angepasst werden, falls die Kurve immer noch zu flach ist und ggf. diesen „leichten Knick“ (ca. bei 2 Minuten zu sehen) hat (siehe Bild P=60 und I=240 und P=45 und I=240).
 
 ## Fall 2) Maschine schwingt über
 
-Hier könnte es helfen erst P zu erhöhen. Falls dies nicht hilft, kann man P wieder auf den ursprünglichen Wert zurückstellen und I leicht erhöhen, dann seht Ihr, wo ihr euch in dem „Kennfeld“ befindet.
+Hier könnte es helfen erst P zu erhöhen. Falls dies nicht hilft, kann man P wieder auf den ursprünglichen Wert zurückstellen und I leicht erhöhen, dann seht ihr, wo ihr euch in dem „Kennfeld“ befindet.

--- a/de/hardware/hardware.md
+++ b/de/hardware/hardware.md
@@ -29,7 +29,7 @@ Das PCB für den Mikrocontroller sieht wie folgt aus:
 ![PCB](../../img/image-3.png)
 
 
-###  Grundversion PID-Only
+###  Grundversion PID Only
 
 Die einzelnen Komponenten werden wie folgt angeschlossen:
 

--- a/de/intro/einleitung.md
+++ b/de/intro/einleitung.md
@@ -51,7 +51,7 @@ Folgende Eckdaten zeichnen unseren DIY PID aus:
 
 ## Universell – Umgebaute Maschinentypen
 
-Entwickelt wurde unser System ursprünglich an einer Rancilio Silvia, es ist aber universell einsatzbar. Bislang haben unsere User die folgenden Maschinen erfolgreich umgebaut:
+Entwickelt wurde unser System ursprünglich an einer Rancilio Silvia, es ist aber universell einsetzbar. Bislang haben unsere User die folgenden Maschinen erfolgreich umgebaut:
 
  * Rancilio Silvia V1 – V4
  * Rancilio Silvia E(co) V5 & V6
@@ -60,6 +60,7 @@ Entwickelt wurde unser System ursprünglich an einer Rancilio Silvia, es ist abe
  * La Pavoni EPL / Saeco Aroma / Gaggia New Classic (9403)
  * E61 Einkreiser (Bazzar A1 Livello, Fiorenzato Colombina)
  * E61 Zweikreiser (Profitec Pro500)
+ * Quick Mill Retro (0835) & Orione (3000) 
 
 ## Aufbau / Unterschiede PID Only vs. Vollausbau
 
@@ -90,7 +91,7 @@ Die Grenzen sind fließend, da auch beim "PID Only" auch nun die Waage genutzt w
 
 Die Grundversion ist ein klassischer PID-Regler: der Temperatursensor nimmt die aktuelle Temperatur des Kessels auf (Input) und gibt den Wert an die PID-Software auf den Mikrocontroller ( auch NodeMCU genannt) weiter. Diese gibt dann das Regler-Signal (Output) an das SSR aus, welches die Heizung eurer Maschine aktiviert bzw. deaktiviert.
 
-Damit habt ihr eine exakte Regelung der Brühtemperatur auf euren Wunschwert durch die PID-Software, die restliche Bedienung eurer Maschine bleibt unangetastet. MQTT, Displayausgabe und Handy Steuerung geht auch bei Only PID
+Damit habt ihr eine exakte Regelung der Brühtemperatur auf euren Wunschwert durch die PID-Software, die restliche Bedienung eurer Maschine bleibt unangetastet. MQTT, Displayausgabe und Handy Steuerung geht auch bei PID Only
 
 ## Erweiterung der Grundversion (PID Only Plus)
 
@@ -108,7 +109,7 @@ Beim Vollausbau gehen wir einen Schritt weiter und überlassen die Ansteuerung d
 
 Beim Vollausbau ändert sich die Bedienung eurer Maschine auch etwas: der Brühschalter, mit dem ihr bislang den Bezug gestartet und auch wieder gestoppt habt, dient nun nur noch als Taster, der den automatisierten Bezug startet. Gestoppt wird der Bezug durch die Software, auch wenn der Schalter noch auf ON steht.
 
-Unsere Empfehlung, basierend auf unseren eigenen Erfahrungen und denen der bislang mehr als 250 User des PIDs, lautet ganz klar, zuerst die Grundversion PID-Only umzusetzen. Damit ist die größte geschmackliche Verbesserung im Vergleich zum vorherigen Serienzustand eurer Maschine zu erwarten. Der Vollausbau ist darauf aufbauend eine Erweiterung der Möglichkeiten, aber gleichzeitig auch ein komplexerer Umbau.  
+Unsere Empfehlung, basierend auf unseren eigenen Erfahrungen und denen der bislang mehr als 250 User des PIDs, lautet ganz klar, zuerst die Grundversion PID Only umzusetzen. Damit ist die größte geschmackliche Verbesserung im Vergleich zum vorherigen Serienzustand eurer Maschine zu erwarten. Der Vollausbau ist darauf aufbauend eine Erweiterung der Möglichkeiten, aber gleichzeitig auch ein komplexerer Umbau.  
 
 ## Vollausbau Plus
 Bei diesem Ausbau bleibt kein Wunsch mehr offen, da das Bezugsgewicht nun die Bezugsdauer steuert. 

--- a/en/hardware/hardware.md
+++ b/en/hardware/hardware.md
@@ -29,7 +29,7 @@ Das PCB für den Mikrocontroller sieht wie folgt aus:
 ![PCB](../../img/image-3.png)
 
 
-###  Grundversion PID-Only
+###  Grundversion PID Only
 
 Die einzelnen Komponenten werden wie folgt angeschlossen:
 

--- a/en/intro/einleitung.md
+++ b/en/intro/einleitung.md
@@ -54,6 +54,7 @@ Our system was originally developed for use in the Rancilio Silvia but can be us
  * La Pavoni EPL / Saeco Aroma / Gaggia New Classic (9403)
  * E61 single boiler (Bazzar A1 Livello, Fiorenzato Colombina)
  * E61 single boiler, dual use (Profitec Pro500)
+ * Quick Mill Retro (0835) & Orione (3000)
 
 ## Differences PID Only vs. full expansion
 


### PR DESCRIPTION
Aufnahme der Quick Mill Maschinen 0835 und 3000 ins Handbuch mit PID-Werten.
Korrektur von Typos.