### PR TITLE
Software Installation: Current projects with ESP32 should use esp8266-master

### DIFF
--- a/de/software-part-I/programmcode.md
+++ b/de/software-part-I/programmcode.md
@@ -81,11 +81,13 @@ Hier geht ihr ein (1): "git: checkout to"
 Drück Return oder klickt per Maus den Befehl an und es erscheint eine Auswahlliste aller Versionen:
 ![](../../img/softwareinstall/swinstall10.png) 
 
-Für den ESP32 sind nur die Versionen ab 4.X.X relevant, in dieser Version wird nicht mehr der ESP8266 unterstützt. 
+In Zukunft sind für den ESP32 sind nur die Versionen ab 4.X.X relevant, in dieser Version wird nicht mehr der ESP8266 unterstützt. 
 Die "origin/master" ist die aktuelle Version der Entwicklung für den ESP32. 
+Da es aktuell noch kein Release der Version 4.X gibt, nutzt für neue ESP32-Projekte bis dahin den Branch `origin/ESP8266-master`. Trotz des Namens wird hier auch der ESP32 unterstützt und ihr bekommt den aktuellsten, stabilen Stand mit korrektem PIN-Layout für die aktuellen PCBs. 
 
-Die Master "origin/ESP8266-master" ist die alte Entwicklungsversion für den ESP8266. Hier gibt es nur noch Bugfixes. Die aktuelle Version vom ESP8266 ist jeweils die Version mit dem Zusatz "-esp8266" z.B: "v3.1.2-esp8266"
-Wählt die aktuellste Version für den ESP32 aus. Es dauert paar Sekunden und dann sollte der Code heruntergeladen sein.
+Die Master "origin/ESP8266-master" ist die (alte) Entwicklungsversion für den ESP8266. Hier gibt es nur noch Bugfixes. Die aktuelle Version vom ESP8266 ist jeweils die Version mit dem Zusatz "-esp8266" z.B: "v3.1.2-esp8266"
+
+Wählt die aktuellste Version (`origin/ESP8266-master` oder in Zukunft Releases 4.x) für den ESP32 aus. Es dauert paar Sekunden und dann sollte der Code heruntergeladen sein.
 
 ##  Compilieren vorbereiten
 Bevor ihr die Version kompilieren könnt müssen noch kleinere Vorbereitungen passieren. 


### PR DESCRIPTION
As mentioned by @LoQue90, freshly started projects should use esp8266 master, which was not reflected in the documentation at all. 

![image](https://github.com/rancilio-pid/ranciliopid-handbook/assets/1345257/a20a439d-561e-4d8d-a609-c77f453584f9)
