### PR TITLE
Add Isomac Zaffiro Parameters

### DIFF
--- a/de/customization/PIDV3.md
+++ b/de/customization/PIDV3.md
@@ -51,16 +51,14 @@ PID BD Sensitivity | Empfindlichkeit der PID Brew Detection im Bezug auf Abfall 
 
 ## Standardwerte für diverse Maschinentypen
 
-### Rancilio Siliva
-
-Parameter | Rancilio Siliva V1-2 | Rancilio Siliva V3-V6 | Rancilio Silvia seitlicher Sensor | Gaggia 9480 | Quickmill
-:--|:--|:--|:-- |:-- |:--
-PID Kp | 62 | 50 | 55 | 130 | 250
-PID Tn (=Kp/Ki) | 52 | 200 | 65 | 130 |25
-PID Tv (=Kd/Kp) | 11.5 | 20 | 13 | 0.54 |68
-PID Integrator Max | 75 | 75 | 75 | 50 | 75
-Steam Kp | 150 | 150 | 150 | 150 | 150
-PID BD Sensitivity | 120 | 60 | 120 | 120 | 80
+Parameter | Rancilio Siliva V1-2 | Rancilio Siliva V3-V6 | Rancilio Silvia seitlicher Sensor | Gaggia 9480 | Quickmill | Isomac Zaffiro
+:--|:--|:--|:-- |:-- |:--|:--
+PID Kp | 62 | 50 | 55 | 130 | 250 | 100
+PID Tn (=Kp/Ki) | 52 | 200 | 65 | 130 | 25 | 75 
+PID Tv (=Kd/Kp) | 11.5 | 20 | 13 | 0.54 |68 | 12,5
+PID Integrator Max | 75 | 75 | 75 | 50 | 75 | 115
+Steam Kp | 150 | 150 | 150 | 150 | 150 | 150
+PID BD Sensitivity | 120 | 60 | 120 | 120 | 80 | 
 
 ## Zusammenhang zwischen Parametern und Reglerverhalten
 

--- a/de/customization/PIDV3.md
+++ b/de/customization/PIDV3.md
@@ -52,13 +52,17 @@ PID BD Sensitivity | Empfindlichkeit der PID Brew Detection im Bezug auf Abfall 
 ## Standardwerte für diverse Maschinentypen
 
 Parameter | Rancilio Siliva V1-2 | Rancilio Siliva V3-V6 | Rancilio Silvia seitlicher Sensor | Gaggia 9480 | Quickmill | Isomac Zaffiro
-:--|:--|:--|:-- |:-- |:--|:--
+:--|:--|:--|:--|:--|:--|:--
 PID Kp | 62 | 50 | 55 | 130 | 250 | 100
 PID Tn (=Kp/Ki) | 52 | 200 | 65 | 130 | 25 | 75 
 PID Tv (=Kd/Kp) | 11.5 | 20 | 13 | 0.54 |68 | 12,5
 PID Integrator Max | 75 | 75 | 75 | 50 | 75 | 115
 Steam Kp | 150 | 150 | 150 | 150 | 150 | 150
-PID BD Sensitivity | 120 | 60 | 120 | 120 | 80 | 
+PID BD Sensitivity | 120 | 60 | 120 | 120 | 80 |
+PID BD Kp |  |  |  |  |  | 200 
+PID BD Tn |  |  |  |  |  | 200 
+PID BD Tv |  |  |  |  |  | 20
+PID BD Time |  |  |  |  |  | 60
 
 ## Zusammenhang zwischen Parametern und Reglerverhalten
 


### PR DESCRIPTION
Compare https://discord.com/channels/741235778021097484/1165701257378418819/1185889881151512638.

Prepared entry for **Isomac Zaffiro** parameters. Assume it is the V3 version. Frank seems to use the Brew PID, which this table is not prepared for. Therefor no `PID BD Sensitivity` is given. Shall I add another table layout for setups with `Brew PID` checked?

![ZI2](https://github.com/rancilio-pid/ranciliopid-handbook/assets/2255804/628c644d-a8bf-4f8d-9c5c-9ff648db2520)
![ZI1](https://github.com/rancilio-pid/ranciliopid-handbook/assets/2255804/dcaf7b51-8ddb-4efe-933f-ff697a69ce55)
