### PR TITLE
Add short hint about "PID is disabled manually" to the "Trockenaufbau" page

### DIFF
--- a/de/hardware/hardware.md
+++ b/de/hardware/hardware.md
@@ -134,3 +134,5 @@ Hier einige gesammelte Hinweise zum Einbau in die Maschine:
 *  Den Temperatursensor solltet ihr wenn möglich nicht nur an den Kessel ankleben, sondern fest verschrauben. Bei der Rancilio Silvia kann man dazu die Halteklammer des nun überflüssigen Brühthermostaten nutzen, bei der Gaggia Classic kann der Sensor am vorhandenen M4-Gewinde der Thermostataufnahme verschraubt werden.
 
 * Zum Anschluss des Temperatursensors TSIC keine Steckverbinder (Jumperkabel) nehmen, sondern Litze an die Beine des TSIC löten. Das ist etwas fummelig, aber dafür habt ihr weniger Neigung zu Wackelkontakten im verbauten Zustand.
+
+* Beim ersten Probelauf nach dem erfolgreichen Zusammenbau muss der PID einmalig über die Konfigurationshomepage aktiviert werden, ansonsten zeigt der Sensor nur "PID is disabled manually" an. Danach sollte das Relais schalten und "heizen". 

--- a/de/hardware/hardware.md
+++ b/de/hardware/hardware.md
@@ -135,4 +135,4 @@ Hier einige gesammelte Hinweise zum Einbau in die Maschine:
 
 * Zum Anschluss des Temperatursensors TSIC keine Steckverbinder (Jumperkabel) nehmen, sondern Litze an die Beine des TSIC löten. Das ist etwas fummelig, aber dafür habt ihr weniger Neigung zu Wackelkontakten im verbauten Zustand.
 
-* Beim ersten Probelauf nach dem erfolgreichen Zusammenbau muss der PID einmalig über die Konfigurationshomepage aktiviert werden, ansonsten zeigt der Sensor nur "PID is disabled manually" an. Danach sollte das Relais schalten und "heizen". 
+* Beim ersten Probelauf nach dem erfolgreichen Zusammenbau muss der PID einmalig über die Konfigurationshomepage aktiviert werden, ansonsten zeigt das Display nur "PID is disabled manually" an. Danach sollte das Relais schalten und "heizen". 

--- a/en/hardware/hardware.md
+++ b/en/hardware/hardware.md
@@ -102,4 +102,4 @@ Hier einige gesammelte Hinweise zum Einbau in die Maschine:
 
 * Zum Anschluss des Temperatursensors TSIC keine Steckverbinder (Jumperkabel) nehmen, sondern Litze an die Beine des TSIC löten. Das ist etwas fummelig, aber dafür habt ihr weniger Neigung zu Wackelkontakten im verbauten Zustand.
 
-* Beim ersten Probelauf nach dem erfolgreichen Zusammenbau muss der PID einmalig über die Konfigurationshomepage aktiviert werden, ansonsten zeigt der Sensor nur "PID is disabled manually" an. Danach sollte das Relais schalten und "heizen".
+* Beim ersten Probelauf nach dem erfolgreichen Zusammenbau muss der PID einmalig über die Konfigurationshomepage aktiviert werden, ansonsten zeigt das Display nur "PID is disabled manually" an. Danach sollte das Relais schalten und "heizen".

--- a/en/hardware/hardware.md
+++ b/en/hardware/hardware.md
@@ -101,3 +101,5 @@ Hier einige gesammelte Hinweise zum Einbau in die Maschine:
 *  Den Temperatursensor solltet ihr wenn möglich nicht nur an den Kessel ankleben, sondern fest verschrauben. Bei der Rancilio Silvia kann man dazu die Halteklammer des nun überflüssigen Brühthermostaten nutzen, bei der Gaggia Classic kann der Sensor am vorhandenen M4-Gewinde der Thermostataufnahme verschraubt werden.
 
 * Zum Anschluss des Temperatursensors TSIC keine Steckverbinder (Jumperkabel) nehmen, sondern Litze an die Beine des TSIC löten. Das ist etwas fummelig, aber dafür habt ihr weniger Neigung zu Wackelkontakten im verbauten Zustand.
+
+* Beim ersten Probelauf nach dem erfolgreichen Zusammenbau muss der PID einmalig über die Konfigurationshomepage aktiviert werden, ansonsten zeigt der Sensor nur "PID is disabled manually" an. Danach sollte das Relais schalten und "heizen".


### PR DESCRIPTION
Added a small hint at the end of the "Trockenaufbau" page where (new) users most likely encounter the "PID is disabled manually" screen for the first time when they want to test their setup.