### PR TITLE
Add GH Action to build page in non-main-branches

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -19,9 +19,9 @@ jobs:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v4
+      # - name: Setup Pages
+      #   id: pages
+      #   uses: actions/configure-pages@v4
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -10,6 +10,7 @@ jobs:
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
   build:
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -27,6 +27,6 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-#      - name: Upload artifact
-#        # Automatically uploads an artifact from the './_site' directory by default
-#        uses: actions/upload-pages-artifact@v3
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,3 +8,25 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+#      - name: Upload artifact
+#        # Automatically uploads an artifact from the './_site' directory by default
+#        uses: actions/upload-pages-artifact@v3

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ remote_theme: pmarsceill/just-the-docs
 color_scheme: "light"
 search_enabled: true
 logo: ./favicon.ico
+repository: rancilio-pid/ranciliopid-handbook
 # Aux links for the upper right navigation
 aux_links:
   "Clever-Coffee Website":


### PR DESCRIPTION
This MR adds a Github Action that will build the static Jekyll page and uploads the built page as artifact. 

If the job succeeds this is a good first hint that any changes done in the branch are OK (w.r.t. to Jekyll) and the downloaded artifact can be run locally to check if all changes compiled as expected.

Open questions: I'm not sure where the Action "pages-build-deployment" is defined, I assume it is some Github Configuration magic happening only on the **main** branch? I've excluded my build job from main to not build twice, but someone with better Github Action knowledge should definitely double-check this.