### PR TITLE
fixed PCB pin names for rev 1.5

### DIFF
--- a/de/platinen/ESP32.md
+++ b/de/platinen/ESP32.md
@@ -35,19 +35,19 @@ Aktuell sind keine Bugs bekannt.
 
 Header | PIN Software | Beschriftung PCB | Belegung
 -|-|-|-
-HT_RL | PIN 2 | IO02 | SSR Heizung
-T_SENS | PIN 16 | IO16 | Temperatursensor
+HT_RL | PIN 2 | OUT | SSR Heizung
+T_SENS | PIN 16 | SIG | Temperatursensor
 I2C | PIN 21 | SDA | Display und Drucksensor - PIN SDA
-I2C | PIN 22 | SDL | Display und Drucksensor - PIN SCL
-V_IN | - | V_IN | Netzteil (5 Volt)
+I2C | PIN 22 | SCL | Display und Drucksensor - PIN SCL
+V_IN | - | 5V | Netzteil (5 Volt)
 PV_RL | PIN 17 | Valve | Relais Ansteuerung Magnetventil
 PV_RL | PIN 27 | Pump | Relais Ansteuerung Pumpe
-BPSW_SW | PIN 34 | IO34 | Bezugsschalter oder Optokoppler
-BPSW_SW | PIN 39 | IO39 | Powerschalter
-BPSW_SW | PIN 35 | IO35 | Dampfschalter
-BPSW_SW | PIN 39 | IO39 | Heißwasserschalter (noch nicht implementiert)
-S_LED | PIN 26 | IO26 | Status oder Temp LED
-W_SENS | PIN 23 | IO23 | Wasserstandssensor
+BPSW_SW | PIN 34 | BREW | Bezugsschalter oder Optokoppler
+BPSW_SW | PIN 39 | PWR | Powerschalter
+BPSW_SW | PIN 35 | STEAM | Dampfschalter
+BPSW_SW | PIN 39 | WATER | Heißwasserschalter (noch nicht implementiert)
+S_LED | PIN 26 | OUT | Status oder Temp LED
+W_SENS | PIN 23 | SIG | Wasserstandssensor
 SCALE | PIN 25 | DAT2 | Waage DAT2
 SCALE | PIN 32 | DAT | Waage DAT
 SCALE | PIN 33 | CLK | Waage CLK

--- a/en/pcb/ESP32.md
+++ b/en/pcb/ESP32.md
@@ -38,19 +38,19 @@ Currently, there are no known bugs.
 
 Header | Pin Software | Pin PCB | Connection
 -|-|-|-
-HT_RL | PIN 2 | IO02 | SSR Heating
-T_SENS | PIN 16 | IO16 | Temperature sensor
+HT_RL | PIN 2 | OUT | SSR Heating
+T_SENS | PIN 16 | SIG | Temperature sensor
 I2C | PIN 21 | SDA | Display and pressure sensor - Pin SDA
-I2C | PIN 22 | SDL | Display and pressure sensor - Pin SCL
-V_IN | - | V_IN | Switching power supply (5 Volt)
+I2C | PIN 22 | SCL | Display and pressure sensor - Pin SCL
+V_IN | - | 5V | Switching power supply (5 Volt)
 PV_RL | PIN 17 | Valve | Relay 3-way-valve
 PV_RL | PIN 27 | Pump | Relay pump
-BPSW_SW | PIN 34 | IO34 | Brew switch or optocoupler
-BPSW_SW | PIN 39 | IO39 | Power switch
-BPSW_SW | PIN 35 | IO35 | Steam switch
-BPSW_SW | PIN 39 | IO39 | Hot water switch (not yet implemented)
-S_LED | PIN 26 | IO26 | Status or Temp LED
-W_SENS | PIN 23 | IO23 | Water level sensor
+BPSW_SW | PIN 34 | BREW | Brew switch or optocoupler
+BPSW_SW | PIN 39 | PWR | Power switch
+BPSW_SW | PIN 35 | STEAM | Steam switch
+BPSW_SW | PIN 39 | WATER | Hot water switch (not yet implemented)
+S_LED | PIN 26 | OUT | Status or Temp LED
+W_SENS | PIN 23 | SIG | Water level sensor
 SCALE | PIN 25 | DAT2 | Scale DAT2
 SCALE | PIN 32 | DAT | Scale DAT
 SCALE | PIN 33 | CLK | Scale CLK


### PR DESCRIPTION
As discussed in discord, the pin names of the ESP32 PCB rev 1.5 do not fit the documentation.