### PR TITLE
Minor improvements

### DIFF
--- a/de/hardware/Einbau.md
+++ b/de/hardware/Einbau.md
@@ -29,6 +29,8 @@ Zeitaufwand:
 * PID Only ca. 3 h
 * Vollaubau weitere 2-3 h
 
+Sieht auch [Tips und Tricks zum Einbau](./hardware.md#tipps-und-tricks)
+
 ## Zerlegen
 
 Als erstes muss die Maschine zerlegt werden. Hier findet ihr einen [Link zur Demontage](https://clevercoffee.de/rancilio-silvia-demontage/).
@@ -54,7 +56,7 @@ Das alte Thermostat beiseite legen und aufheben; bereich von der Wärmeleitpaste
 Bügel mit Schraube, Beilagscheiben und Muttern vorbereiten. Bügel wieder einbauen dabei Schraube 3 und 2 festziehen, 1 noch etwas locker lassen.
 
 Die neue Schraube mit Hilfe der zwei Muttern so einstellen, dass die Schraube auf dem Temperatursensor aufliegt. Muttern festziehen.
-Temperatursensor auf der Unterseite mit etwas Wärmeleitpaste versehen, unter der neuen Schraube platzieren und Schraube 1 anziehen. Der Bügel sollte sich dabei leicht verformen. So wird sichergestellt, dass der Sensor fest sitzt, aber nicht zu sehr gequetscht wird.  
+Temperatursensor auf der Unterseite mit etwas Wärmeleitpaste versehen (siehe [Infos zum Wärmeleitkleber](../bestellliste.md#infos-zum-wärmeleitkleber)), unter der neuen Schraube platzieren und Schraube 1 anziehen. Der Bügel sollte sich dabei leicht verformen. So wird sichergestellt, dass der Sensor fest sitzt, aber nicht zu sehr gequetscht wird.
 
 
 ### Stromversorgung
@@ -77,7 +79,7 @@ Montagepunkt für das SSR festlegen. Es kann bei der Rancilio Silvia E z.B. übe
 An Kabel 2 (blau) des Schrittes oben, eine Ringöse pressen (Kabel vor dem Anschließen entsprechend kürzen) und an einen beliebigen Pol des SSR-Ausgangs anschließen.
 Ein weiteres Kabel 1,5 mm2 mit einer Ringöse versehen und am zweiten Pol des SSR-Ausgangs befestigen. Kabel zum Stecker mit dem grauen Kabel verlegen, welches ursprünglich am Thermostat war und entsprechend kürzen. Einen Flachstecker aufpressen und anschließend mit einem Schrumpfschlauch versehen.
 
-Zwei Kabel (rot und schwarz) an der Eingangsseite des SSR anschließen. Ich habe dafür 0,5 mm2 Kabel verwendet und ebenfals Ringösen aufgepresst. Es können aber auch die 0,14 mm2 Kabel mit Aderendhülsen o.ä. verwendet werden.
+Zwei Kabel (rot und schwarz) an der Eingangsseite des SSR anschließen (siehe [SSR anschließen](./hardware.md#ssr-anschließen)). Ich habe dafür 0,5 mm2 Kabel verwendet und ebenfals Ringösen aufgepresst. Es können aber auch die 0,14 mm2 Kabel mit Aderendhülsen o.ä. verwendet werden.
 Freie Kabelenden beschriften und richtung 3-Wegeventil legen.
 
 ### Einbau des Controllers

--- a/de/software-part-I/programmcode.md
+++ b/de/software-part-I/programmcode.md
@@ -124,6 +124,7 @@ WICHTIG: Haltet die Taste "Boot" auf dem ESP gedrückt (ohne Pins kurzzuschließ
 ![](../../img/software-part-I/softwareinstall/swinstall13.png)
 
 Bei jedem Teilschritt das `SUCCESS` in der Konsole abwarten:
+
 * (1) Daher wählt `esp32_usb` aus
 * (2) `Erase flash` (Boottaste am ESP32 drücken) klicken, warten bis `SUCCESS`
 * (3) `Build Filesystem Image` klicken, warten bis `SUCCESS`
@@ -146,4 +147,4 @@ Bei jedem Teilschritt das `SUCCESS` in der Konsole abwarten:
 *wm:[1] Connect Wifi, ATTEMPT # 2 of 3
 ```
 
-Glückwunsch, der ESP32 (oder ESP8266) ist nun mit der Software bespielt, weiter geht es mit der Einrichtung des WLANs!
+Glückwunsch, der ESP32 (oder ESP8266) ist nun mit der Software bespielt, weiter geht es mit der [Einrichtung des WLANs!](./ErsteinrichtungWLAN.md)

--- a/de/software-part-I/programmcode.md
+++ b/de/software-part-I/programmcode.md
@@ -70,8 +70,6 @@ WICHTIG! Nach der Installation muss der Rechner neugestartet werden!
 
 ## Auswahl der Software-Version für den ESP32
 Nach dem Neustart des Rechners könnt ihr prüfen, ob ihr die Software kompilieren könnt.
-Öffnet das Verzeichnis in VS Code, welches ihr in GitHub kopiert habt. `File` -> `Open Folder`.
-In dem oberen Fall wäre dies `/Documents/Github/clevercoffee`.
 
 In VS Code drückt ihr in MacOS `Shift` + `CMD` + `P` oder nutzt die Taskleiste von VS Code: `View` -> `Command Palette`.
 Hier gebt ihr ein (1): `git: clone`

--- a/de/software-part-I/programmcode.md
+++ b/de/software-part-I/programmcode.md
@@ -95,9 +95,13 @@ Drückt Return oder klickt per Maus den Befehl an und es erscheint eine Auswahll
 
 ![](../../img/software-part-I/softwareinstall/swinstall10.png)
 
-Für den ESP32 sind nur die Versionen ab 4.X.X relevant, in dieser Version wird nicht mehr der ESP8266 unterstützt.
-Die Version `origin/master` ist die aktuelle Version der Entwicklung für den ESP32.
+### Version 4.X.X - ESP32-only
+Für den ESP32 sind nur die Versionen ab 4.X.X relevant bzw. der aktuelle `master`. In dieser Version wird nicht mehr der ESP8266 unterstützt.
 
+> Aktuell gibt es noch keinen 4.X.X branch, also muss der aktuelle master branch verwendet werden
+<!-- TODO, maybe one could use a callout here,  -->
+
+### Version 3.X.X - ESP8266/ESP32
 Die Version `origin/ESP8266-master` ist die alte Entwicklungsversion für den ESP8266. Hier gibt es nur noch Bugfixes. Die aktuelle Version für den ESP8266 ist jeweils die Version mit dem Zusatz `-esp8266` zum Beispiel: `v3.1.2-esp8266`
 
 Wählt die aktuellste Version für den ESP32 aus. Es dauert ein paar Sekunden und dann sollte der Code heruntergeladen sein.
@@ -109,11 +113,6 @@ Geht in VS Code in den Verzeichnisbaum des Codes, öffnet den Ordner `/src` und 
 
 ![](../../img/software-part-I/softwareinstall/swinstall12.png)
 
-Für den ESP32 sind nur die Versionen ab 4.X.X relevant, in dieser Version wird nicht mehr der ESP8266 unterstützt. 
-Die "origin/master" ist die aktuelle Version der Entwicklung für den ESP32. 
-
-Die Master "origin/ESP8266-master" ist die alte Entwicklungsversion für den ESP8266. Hier gibt es nur noch Bugfixes. Die aktuelle Version vom ESP8266 ist jeweils die Version mit dem Zusatz "-esp8266" z.B: "v3.1.2-esp8266"
-Wählt die aktuellste Version für den ESP32 aus. Es dauert paar Sekunden und dann sollte der Code heruntergeladen sein.
 
 ##  Kompilieren
 Nun kann der Code kompiliert werden. Hierzu sind folgende Schritte notwendig:

--- a/de/software-part-I/programmcode.md
+++ b/de/software-part-I/programmcode.md
@@ -40,12 +40,6 @@ Hierbei kann unten rechts im Fenster eine Meldung zeigen, dass weitere Softwarep
 Zum Beispiel muss Python extern installiert werden. Durch den Klick auf `Install Python` (1) gelangt ihr in die Dokumentation von PlatformIO. Befolgt dort die weiteren Installationsschritte. Klickt dann in VS Code in der Meldung `Try again`.
 Am Ende zeigt euch folgende Meldung, dass PlatformIO erfolgreich installiert wurde:
 
-![](../../img/software-part-I/softwareinstall/swinstall3.png)
-
-Ihr könnt aber zum aktuellen Stand ohne `git` oder GitHub Desktop nicht unseren Code kompilieren. Falls ihr dies doch tut erhaltet ihr zum Beispiel eine folgende Fehlermeldung:
-
-![](../../img/software-part-I/softwareinstall/swinstall4.png)
-
 Ihr könnt an dieser Stelle VS Code erst einmal schließen.
 
 


### PR DESCRIPTION
This PR updates a few parts in the documentation I stumbled over when upgrading my Silvia to PID-Only last week. It should just point out a few points where I myself was confused ^^ and I tried to offer some minimally invasive quickfixes.

In the `Software` section, there were a few (maybe orphaned) sections which left me confused. Such as 

- a note about a future step not working now 
- or a sentence about a step that apparently was already executed but it was nowhere in the guide until then. 
- Mentioning a branch/version which is not available yet 
- Repeating information

And then there was information scattered at different places and it was hard to find. E.g. there is information about the heat conduction paste in the `BOM` but nowhere near the section in the `Einbau` where it is actually used. There is also a `Tips and Tricks` section in the `BOM` but no references to it where it was actually applied. I tried to mitigate this by adding some references to these sections where it could have helped me. 


### ToDos

- [ ] After reviewed, update english version 
- [ ] What about Linting? 
    - [ ] In the README there is a note about automatic linting but if I understood correctly, this just checks for broken links. Is there any plan to actually add linting (using github actions or a pre-commit hook)? 
 - [ ] There were images in `https://clevercoffee.de/bauberichte/` which were crucial for some parts e.g. for me to know where the thermostat actually lives or to know which screw is `Schraube 1/2/3` . Would referencing these in the `Einbau` section make sense? 